### PR TITLE
Fix: save sections and widgets when saving homework as draft

### DIFF
--- a/src/homeworks/tests/test_draft_mode_views.py
+++ b/src/homeworks/tests/test_draft_mode_views.py
@@ -42,6 +42,9 @@ def _make_section_post(sections, prefix="sections"):
         data[f"{prefix}-{i}-content"] = s.get("content", "")
         data[f"{prefix}-{i}-order"] = str(s.get("order", i + 1))
         data[f"{prefix}-{i}-solution"] = s.get("solution", "")
+        data[f"{prefix}-{i}-section_type"] = s.get("section_type", "conversation")
+        if s.get("DELETE"):
+            data[f"{prefix}-{i}-DELETE"] = "1"
     return data
 
 
@@ -301,6 +304,84 @@ class EditViewDraftSaveTests(DraftViewsSetUpMixin):
         response = self.client.post(self._edit_url(), data)
         # Should redirect, not re-render the form
         self.assertEqual(response.status_code, 302)
+
+    def test_save_draft_creates_new_sections(self):
+        """save_draft should create sections passed in the POST data."""
+        self.client.login(username="teacher", password="pass")
+        section_data = _make_section_post(
+            [
+                {"title": "Exercise 1", "content": "Solve x+2=5", "order": 1},
+                {"title": "Exercise 2", "content": "Solve 2y=10", "order": 2},
+            ]
+        )
+        data = {"title": "T", "description": "D", "save_draft": "1", **section_data}
+        response = self.client.post(self._edit_url(), data)
+        self.assertEqual(response.status_code, 302)
+
+        self.draft.refresh_from_db()
+        sections = list(self.draft.sections.all().order_by("order"))
+        self.assertEqual(len(sections), 2)
+        self.assertEqual(sections[0].title, "Exercise 1")
+        self.assertEqual(sections[0].content, "Solve x+2=5")
+        self.assertEqual(sections[1].title, "Exercise 2")
+        self.assertEqual(sections[1].content, "Solve 2y=10")
+
+    def test_save_draft_updates_existing_sections(self):
+        """save_draft should update existing sections."""
+        from homeworks.models import Section
+
+        section = Section.objects.create(
+            homework=self.draft,
+            title="Old Title",
+            content="Old content",
+            order=1,
+        )
+        self.client.login(username="teacher", password="pass")
+        section_data = _make_section_post(
+            [
+                {
+                    "id": str(section.id),
+                    "title": "New Title",
+                    "content": "New content",
+                    "order": 1,
+                }
+            ]
+        )
+        data = {"title": "T", "description": "D", "save_draft": "1", **section_data}
+        response = self.client.post(self._edit_url(), data)
+        self.assertEqual(response.status_code, 302)
+
+        section.refresh_from_db()
+        self.assertEqual(section.title, "New Title")
+        self.assertEqual(section.content, "New content")
+
+    def test_save_draft_deletes_sections(self):
+        """save_draft should delete sections marked for deletion."""
+        from homeworks.models import Section
+
+        section = Section.objects.create(
+            homework=self.draft,
+            title="Remove Me",
+            content="content",
+            order=1,
+        )
+        self.client.login(username="teacher", password="pass")
+        section_data = _make_section_post(
+            [
+                {
+                    "id": str(section.id),
+                    "title": "Remove Me",
+                    "content": "content",
+                    "order": 1,
+                    "DELETE": "1",
+                }
+            ]
+        )
+        data = {"title": "T", "description": "D", "save_draft": "1", **section_data}
+        response = self.client.post(self._edit_url(), data)
+        self.assertEqual(response.status_code, 302)
+
+        self.assertFalse(Section.objects.filter(id=section.id).exists())
 
 
 # ---------------------------------------------------------------------------

--- a/src/homeworks/views.py
+++ b/src/homeworks/views.py
@@ -541,6 +541,100 @@ class HomeworkEditView(View):
             homework.homework_type = HomeworkType.DRAFT
             homework.is_hidden = True
             homework.save(update_fields=update_fields)
+
+            # Process sections from POST data (bypass formset validation).
+            # SectionForm requires title/content, but on a draft save the teacher
+            # may have partially-written exercises. We parse raw POST fields to
+            # persist whatever they've entered so far, even if incomplete.
+            sections_total = int(request.POST.get("sections-TOTAL_FORMS", 0))
+            sections_to_update: list[dict[str, Any]] = []
+            sections_to_create: list[SectionCreateData] = []
+            sections_to_delete: list[UUID] = []
+
+            for i in range(sections_total):
+                section_id = request.POST.get(f"sections-{i}-id", "")
+                section_delete = request.POST.get(f"sections-{i}-DELETE", "")
+
+                if section_delete and section_id:
+                    sections_to_delete.append(UUID(section_id))
+                    continue
+
+                section_title = request.POST.get(f"sections-{i}-title", "")
+                section_content = request.POST.get(f"sections-{i}-content", "")
+                section_order = int(request.POST.get(f"sections-{i}-order", i + 1))
+                section_solution = request.POST.get(f"sections-{i}-solution", "")
+                section_type = request.POST.get(
+                    f"sections-{i}-section_type", "conversation"
+                )
+
+                if section_id:
+                    sections_to_update.append(
+                        {
+                            "id": UUID(section_id),
+                            "title": section_title,
+                            "content": section_content,
+                            "order": section_order,
+                            "solution": section_solution,
+                            "section_type": section_type,
+                        }
+                    )
+                else:
+                    sections_to_create.append(
+                        SectionCreateData(
+                            title=section_title,
+                            content=section_content,
+                            order=section_order,
+                            solution=section_solution,
+                            section_type=section_type,
+                        )
+                    )
+
+            # Process widgets from POST data (bypass formset validation)
+            widgets_total = int(request.POST.get("widgets-TOTAL_FORMS", 0))
+            widgets_to_update: list[dict[str, Any]] = []
+            widgets_to_create: list[dict[str, Any]] = []
+            widgets_to_delete: list[UUID] = []
+
+            for i in range(widgets_total):
+                widget_id = request.POST.get(f"widgets-{i}-id", "")
+                widget_delete = request.POST.get(f"widgets-{i}-DELETE", "")
+
+                if widget_delete and widget_id:
+                    widgets_to_delete.append(UUID(widget_id))
+                    continue
+
+                widget_pre_prompt = request.POST.get(f"widgets-{i}-pre_prompt", "")
+                widget_post_prompt = request.POST.get(f"widgets-{i}-post_prompt", "")
+                widget_order = int(request.POST.get(f"widgets-{i}-order", i + 1))
+
+                if widget_id:
+                    widgets_to_update.append(
+                        {
+                            "id": UUID(widget_id),
+                            "pre_prompt": widget_pre_prompt,
+                            "post_prompt": widget_post_prompt,
+                            "order": widget_order,
+                        }
+                    )
+                else:
+                    widgets_to_create.append(
+                        {
+                            "pre_prompt": widget_pre_prompt,
+                            "post_prompt": widget_post_prompt,
+                            "order": widget_order,
+                        }
+                    )
+
+            update_data = HomeworkUpdateData(
+                sections_to_update=sections_to_update or None,
+                sections_to_create=sections_to_create or None,
+                sections_to_delete=sections_to_delete or None,
+                widgets_to_update=widgets_to_update or None,
+                widgets_to_create=widgets_to_create or None,
+                widgets_to_delete=widgets_to_delete or None,
+            )
+            HomeworkService.update_homework(homework.id, update_data)
+
             return HomeworkFormData(
                 form=HomeworkEditForm(instance=homework),
                 section_forms=None,  # type: ignore[arg-type]


### PR DESCRIPTION
The draft save path in HomeworkEditView only persisted the homework metadata (title, description, type) but completely ignored sections and widgets from the POST data. When a teacher wrote exercises and clicked 'Save Draft', the exercises were lost.

**Fix**: Parse sections and widgets directly from POST data (bypassing formset validation since drafts should be lenient), then delegate to HomeworkService.update_homework() to persist everything.

**Tests added**:
- test_save_draft_creates_new_sections — verifies new sections created via draft save
- test_save_draft_updates_existing_sections — verifies existing sections updated via draft save
- test_save_draft_deletes_sections — verifies sections deleted via draft save

Fixes the issue where teachers lose exercises when saving a homework as draft.