### PR TITLE
Fix: dark mode for teacher views

### DIFF
--- a/src/homeworks/templates/homeworks/form.html
+++ b/src/homeworks/templates/homeworks/form.html
@@ -48,6 +48,20 @@
   #publish-at-wrapper {
     transition: opacity 0.2s ease;
   }
+
+  @media (prefers-color-scheme: dark) {
+    .section-form {
+      background-color: #2d2d2d;
+      border-color: #404040;
+    }
+    .widget-form {
+      background-color: #1a3a2a;
+      border-color: #2d5a3d;
+    }
+    .field-hint {
+      color: #a0b0c0;
+    }
+  }
 </style>
 {% endblock %}
 

--- a/src/homeworks/templates/homeworks/matrix.html
+++ b/src/homeworks/templates/homeworks/matrix.html
@@ -436,6 +436,78 @@
         min-width: 120px;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    .matrix-container {
+        border-color: #404040;
+    }
+
+    .matrix-table thead {
+        background-color: #2d2d2d;
+    }
+
+    .matrix-table thead th {
+        background-color: #2d2d2d;
+        border-bottom-color: #404040;
+    }
+
+    .sticky-cell {
+        background-color: #2d2d2d;
+    }
+
+    .matrix-table thead .sticky-cell {
+        background-color: #363636;
+    }
+
+    .student-cell {
+        border-right-color: #404040;
+    }
+
+    .student-name {
+        color: #e0e0e0;
+    }
+
+    .summary-header {
+        background-color: #363636 !important;
+    }
+
+    .summary-cell {
+        background-color: #2d2d2d;
+        border-left-color: #404040;
+    }
+
+    .status-submitted {
+        background-color: #1a4d2a !important;
+        border-color: #2d7b3d !important;
+    }
+
+    .status-in-progress {
+        background-color: #4d3a1a !important;
+        border-color: #7b5a2d !important;
+    }
+
+    .status-not-started {
+        background-color: #2d2d2d !important;
+        border-color: #404040 !important;
+    }
+
+    .status-overdue {
+        background-color: #4d1a1a !important;
+        border-color: #7b2d2d !important;
+    }
+
+    .legend-box {
+        border-color: #404040;
+    }
+
+    .student-row:hover {
+        background-color: #363636;
+    }
+
+    .student-row:hover .sticky-cell {
+        background-color: #404040;
+    }
+}
 </style>
 
 <script>

--- a/src/homeworks/templates/homeworks/submissions.html
+++ b/src/homeworks/templates/homeworks/submissions.html
@@ -348,5 +348,11 @@ document.addEventListener('DOMContentLoaded', function() {
     padding-top: 0.5rem;
     margin-top: 0.5rem;
 }
+
+@media (prefers-color-scheme: dark) {
+    .conversations-in-section {
+        border-top-color: #404040;
+    }
+}
 </style>
 {% endblock %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -46,9 +46,18 @@ body {
         border-bottom-color: #404040;
     }
 
+    .card-header.bg-light {
+        background-color: #363636 !important;
+    }
+
     .bg-light {
         background-color: #2d2d2d !important;
         color: #e0e0e0 !important;
+    }
+
+    .bg-white {
+        background-color: #2d2d2d !important;
+        color: #e0e0e0;
     }
 
     /* Forms */


### PR DESCRIPTION
## Summary

Fixes dark mode rendering issues in teacher-facing views. The problem was that several templates used hardcoded light-mode colors and Bootstrap utility classes (like `bg-white`) that were not overridden in the dark mode CSS.

## Changes

### `static/css/main.css`
- Added `.bg-white` dark mode override (was the most widespread issue — used in submissions, conversations detail pages)
- Added `.card-header.bg-light` override to ensure proper dark shading on card headers

### `src/homeworks/templates/homeworks/matrix.html`
- Added comprehensive `@media (prefers-color-scheme: dark)` block for all inline styles: matrix borders, sticky cells, summary headers/cells, status colors (submitted/in-progress/not-started/overdue), row hover effects, legend boxes

### `src/homeworks/templates/homeworks/submissions.html`
- Added dark mode override for `.conversations-in-section` border color

### `src/homeworks/templates/homeworks/form.html`
- Added dark mode overrides for `.section-form`, `.widget-form`, and `.field-hint` colors

## Testing
- All 851 tests pass