### PR TITLE
Allow teachers/TAs to try conversations safely

### DIFF
--- a/src/conversations/models.py
+++ b/src/conversations/models.py
@@ -126,7 +126,7 @@ class Submission(models.Model):
     @property
     def student(self):
         """Get the student through the conversation."""
-        return self.conversation.user.student_profile
+        return getattr(self.conversation.user, "student_profile", None)
 
     def clean(self):
         """Ensure only one submission per student per section."""

--- a/src/conversations/services.py
+++ b/src/conversations/services.py
@@ -819,7 +819,7 @@ class SubmissionService:
         conversation_id: UUID
         section_id: UUID
         section_title: str
-        student_id: UUID
+        student_id: UUID | None
         student_name: str
         submitted_at: datetime
 
@@ -904,8 +904,9 @@ class SubmissionService:
                 "conversation__user__student_profile", "conversation__section"
             ).get(id=submission_id)
 
-            # Get student's name
+            # Get student's name and profile
             user = submission.conversation.user
+            student_profile = getattr(user, "student_profile", None)
             student_name = f"{user.first_name} {user.last_name}"
             if not student_name.strip():
                 student_name = user.username
@@ -916,7 +917,7 @@ class SubmissionService:
                 conversation_id=submission.conversation.id,
                 section_id=submission.conversation.section.id,
                 section_title=submission.conversation.section.title,
-                student_id=submission.conversation.user.student_profile.id,
+                student_id=student_profile.id if student_profile else None,
                 student_name=student_name,
                 submitted_at=submission.submitted_at,
             )

--- a/src/conversations/tests/test_models.py
+++ b/src/conversations/tests/test_models.py
@@ -405,6 +405,14 @@ class SubmissionModelTest(TestCase):
         submission = Submission.objects.create(**self.submission_data)
         self.assertEqual(submission.student, self.student)
 
+    def test_submission_student_property_with_teacher_conversation(self):
+        """Submission.student should return None for teacher test conversations."""
+        teacher_conv = Conversation.objects.create(
+            user=self.teacher_user, section=self.section
+        )
+        submission = Submission.objects.create(conversation=teacher_conv)
+        self.assertIsNone(submission.student)
+
     def test_submission_clean_method_validation(self):
         """Test submission clean method validation."""
         # Create first submission

--- a/src/conversations/tests/test_submission_service.py
+++ b/src/conversations/tests/test_submission_service.py
@@ -125,6 +125,19 @@ class TestSubmissionService(SubmissionServiceTestCase):
         self.assertEqual(data.student_id, self.student.id)
         self.assertIn(self.student_user.username, data.student_name)
 
+    def test_get_submission_data_with_teacher_conversation(self):
+        """get_submission_data should handle teacher-owned conversations."""
+        teacher_conv = Conversation.objects.create(
+            user=self.teacher_user, section=self.section
+        )
+        submission = Submission.objects.create(conversation=teacher_conv)
+
+        data = SubmissionService.get_submission_data(submission.id)
+
+        self.assertIsNotNone(data)
+        self.assertEqual(data.id, submission.id)
+        self.assertEqual(data.conversation_id, teacher_conv.id)
+
     def test_get_student_submissions(self):
         """Test retrieving all submissions for a student."""
         # Create two submissions for different sections

--- a/src/homeworks/services.py
+++ b/src/homeworks/services.py
@@ -90,6 +90,8 @@ class SectionData:
     status: SectionStatus | None = None
     conversation_id: UUID | None = None
     answer_count: int = 0
+    # Teacher test conversations (populated in view for teachers/TAs)
+    conversations: list[dict] | None = None
 
     @property
     def has_solution(self) -> bool:
@@ -678,6 +680,8 @@ class HomeworkService:
 
             # Populate conversation map
             for conv in conversations:
+                if not hasattr(conv.user, "student_profile"):
+                    continue
                 student_id = conv.user.student_profile.id
                 homework_id = conv.section.homework.id
                 key = (student_id, homework_id)
@@ -883,6 +887,8 @@ class HomeworkService:
             submission_map = {sub.conversation.id: sub for sub in submissions}
 
             for conv in conversations:
+                if not hasattr(conv.user, "student_profile"):
+                    continue
                 student_id = conv.user.student_profile.id
                 homework_id = conv.section.homework.id
                 key = (student_id, homework_id)
@@ -897,6 +903,8 @@ class HomeworkService:
                 tuple[UUID, UUID], datetime
             ] = {}
             for answer in section_answers:
+                if not hasattr(answer.user, "student_profile"):
+                    continue
                 student_id = answer.user.student_profile.id
                 homework_id = answer.section.homework.id
                 key = (student_id, homework_id)

--- a/src/homeworks/templates/homeworks/detail.html
+++ b/src/homeworks/templates/homeworks/detail.html
@@ -158,6 +158,36 @@
                     </zero-md>
                     </div>
 
+                    {% if 'teacher' in data.user_roles and section.section_type != 'non_interactive' %}
+                    <div class="mb-3">
+                        <a href="{% url 'conversations:start' section_id=section.id %}" class="btn btn-outline-primary btn-sm">
+                            <i class="bi bi-play-circle"></i> Try Conversation
+                        </a>
+                    </div>
+                    {% endif %}
+
+                    {% if 'teacher_assistant' in data.user_roles and section.section_type != 'non_interactive' %}
+                    <div class="mb-3">
+                        <a href="{% url 'conversations:start' section_id=section.id %}" class="btn btn-outline-primary btn-sm">
+                            <i class="bi bi-play-circle"></i> Test Conversation
+                        </a>
+                    </div>
+                    {% endif %}
+
+                    {% if section.conversations %}
+                    <div class="mb-3">
+                        <h6 class="text-muted mb-2">Previous Conversations</h6>
+                        <div class="list-group">
+                            {% for conv in section.conversations %}
+                            <a href="{% url 'conversations:detail' conversation_id=conv.id %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center py-2">
+                                <span>{{ conv.label }}</span>
+                                <span class="badge bg-secondary rounded-pill">{{ conv.message_count }} messages</span>
+                            </a>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% endif %}
+
                     {% if 'student' in data.user_roles %}
                     <div class="mb-3">
                         {% if data.widget_progress and not data.widget_progress.all_pre_answered %}

--- a/src/homeworks/templates/homeworks/section_detail.html
+++ b/src/homeworks/templates/homeworks/section_detail.html
@@ -83,7 +83,7 @@
             {% if data.conversations %}
             <div class="list-group">
                 {% for conversation in data.conversations %}
-                <a href="#" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                <a href="{% url 'conversations:detail' conversation_id=conversation.id %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                     <div>
                         <h5 class="mb-1">
                             {{ conversation.label }}

--- a/src/homeworks/tests/test_matrix_view.py
+++ b/src/homeworks/tests/test_matrix_view.py
@@ -650,3 +650,29 @@ class HomeworkMatrixViewTest(TestCase):
             "TA with student profile should not appear in matrix",
         )
         self.assertEqual(matrix_data.total_students, 2)
+
+    def test_matrix_with_teacher_test_conversations_ignored(self):
+        """Teacher test conversations should not crash get_course_homework_matrix."""
+        Conversation.objects.create(user=self.teacher_user, section=self.section1_1)
+
+        matrix_data = HomeworkService.get_course_homework_matrix(self.course.id)
+
+        self.assertIsNotNone(matrix_data)
+        self.assertEqual(matrix_data.total_students, 2)
+        for student_row in matrix_data.student_rows:
+            for cell in student_row.homework_cells:
+                self.assertEqual(cell.submitted_sections, 0)
+                self.assertEqual(cell.total_conversations, 0)
+
+    def test_all_homework_matrix_with_teacher_conversations(self):
+        """Teacher test conversations should not crash get_all_homework_matrix."""
+        Conversation.objects.create(user=self.teacher_user, section=self.section1_1)
+
+        matrix_data = HomeworkService.get_all_homework_matrix(self.teacher.id)
+
+        self.assertIsNotNone(matrix_data)
+        self.assertEqual(matrix_data.total_students, 2)
+        for student_row in matrix_data.student_rows:
+            for cell in student_row.homework_cells:
+                self.assertEqual(cell.submitted_sections, 0)
+                self.assertEqual(cell.total_conversations, 0)

--- a/src/homeworks/views.py
+++ b/src/homeworks/views.py
@@ -994,9 +994,41 @@ class HomeworkDetailView(View):
                 pass
 
         if homework_detail.sections:
+            # Gather teacher/TA test conversations per section
+            teacher_conversations_map: dict[UUID, list[dict]] = {}
+            if "teacher" in user_roles or "teacher_assistant" in user_roles:
+                from conversations.models import Conversation as ConvModel
+
+                section_ids = [s.id for s in homework_detail.sections]
+                test_convs = (
+                    ConvModel.objects.filter(
+                        user=user,
+                        section_id__in=section_ids,
+                        is_deleted=False,
+                    )
+                    .select_related("section")
+                    .prefetch_related("messages")
+                )
+                for conv in test_convs:
+                    section_id = conv.section.id
+                    if section_id not in teacher_conversations_map:
+                        teacher_conversations_map[section_id] = []
+                    teacher_conversations_map[section_id].append(
+                        {
+                            "id": conv.id,
+                            "created_at": conv.created_at,
+                            "updated_at": conv.updated_at,
+                            "message_count": conv.message_count,
+                            "label": f"Test conversation {conv.created_at.strftime('%Y-%m-%d %H:%M')}",
+                        }
+                    )
+
             for section_data in homework_detail.sections:
                 # Get progress data for this section if available
                 progress: SectionData | None = section_progress_map.get(section_data.id)
+
+                # Get teacher test conversations for this section
+                convs = teacher_conversations_map.get(section_data.id)
 
                 sections.append(
                     SectionData(
@@ -1011,6 +1043,7 @@ class HomeworkDetailView(View):
                         status=progress.status if progress else None,
                         conversation_id=progress.conversation_id if progress else None,
                         answer_count=progress.answer_count if progress else 0,
+                        conversations=convs,
                     )
                 )
 


### PR DESCRIPTION
## Changes

- **Fix broken conversation links** in section_detail template (were `href='#'`)
- **Add 'Try Conversation' button** for teachers on homework detail page
- **Add 'Test Conversation' button** for TAs on homework detail page
- **List old test conversations** below the button for resuming
- **Guard all student_profile accesses** against teacher/TA test conversations:
  - `get_all_homework_matrix` and `get_course_homework_matrix`
  - `Submission.student` property
  - `get_submission_data`
- **Add 4 tests** covering teacher test conversations in matrix, submission service, and model edge cases

## Testing

All 855 tests pass, ruff formatting/lint and mypy type checking are clean.